### PR TITLE
feat(auth): Implementa rota de Login (POST /auth/login) com JWT (Issue 4)

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from '../users/dto/create-user.dto';
+import { LoginDto } from './dto/login.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -9,5 +10,10 @@ export class AuthController {
   @Post('register')
   async register(@Body() createUserDto: CreateUserDto) {
     return this.authService.register(createUserDto);
+  }
+
+  @Post('login')
+  async login(@Body() loginDto: LoginDto) {
+    return this.authService.login(loginDto);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,29 +1,58 @@
-import { Injectable, ConflictException } from '@nestjs/common';
+import {
+  Injectable,
+  UnauthorizedException,
+  ConflictException,
+} from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { CreateUserDto } from '../users/dto/create-user.dto';
+import { LoginDto } from './dto/login.dto';
+import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class AuthService {
-  constructor(private usersService: UsersService) {}
+  constructor(
+    private usersService: UsersService,
+    private jwtService: JwtService,
+  ) {}
 
   async register(createUserDto: CreateUserDto) {
     const userExists = await this.usersService.findByEmail(createUserDto.email);
     if (userExists) {
       throw new ConflictException('Este email já está em uso');
     }
-
     const salt = await bcrypt.genSalt();
     const hashedPassword = await bcrypt.hash(createUserDto.password, salt);
-
     const userToCreate = {
       ...createUserDto,
       password: hashedPassword,
     };
-
     const createdUser = await this.usersService.create(userToCreate);
-
     const { password, ...result } = createdUser.toObject();
     return result;
+  }
+
+  async login(loginDto: LoginDto) {
+    const user = await this.usersService.findByEmail(loginDto.email);
+
+    if (!user) {
+      throw new UnauthorizedException('Credenciais inválidas');
+    }
+
+    const isPasswordMatching = await bcrypt.compare(
+      loginDto.password,
+      user.password,
+    );
+
+    if (!isPasswordMatching) {
+      throw new UnauthorizedException('Credenciais inválidas');
+    }
+
+    const payload = { sub: user._id, email: user.email };
+    const accessToken = await this.jwtService.signAsync(payload);
+
+    return {
+      access_token: accessToken,
+    };
   }
 }

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsString, IsNotEmpty } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail({}, { message: 'Por favor, insira um email válido' })
+  @IsNotEmpty({ message: 'O email não pode estar vazio' })
+  email: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'A senha não pode estar vazia' })
+  password: string;
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,5 +1,3 @@
-// src/users/users.service.ts
-
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';


### PR DESCRIPTION
Este PR implementa a funcionalidade de login de usuário na API, conforme descrito na **Issue #4**.

### O que foi feito:

* **Criação do `LoginDto`:** Um novo DTO (`login.dto.ts`) foi criado com validação para `email` e `password`.
* **Injeção do `JwtService`:** O `AuthService` agora injeta o `JwtService` (configurado na Issue 3) para gerar os tokens.
* **Lógica no `AuthService`:** O método `login` foi implementado:
    1.  Encontra o usuário pelo email (via `usersService.findByEmail`).
    2.  Lança um `UnauthorizedException (401)` se o usuário não for encontrado.
    3.  Compara a senha enviada com o hash salvo no banco usando `bcrypt.compare`.
    4.  Lança um `UnauthorizedException (401)` se a senha for inválida (validado via Postman).
    5.  Gera um `access_token` JWT (`{ sub: user._id, email: user.email }`) se as credenciais forem válidas.
* **Rota no `AuthController`:** Criado o endpoint `POST /auth/login` que usa o `LoginDto` e chama o `authService.login`.

A autenticação (Cadastro e Login) está agora 100% funcional.

Closes #4