### PR TITLE
feat(auth): Implementa JwtAuthGuard global para proteger rotas (Issue 5)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { VehiclesModule } from './vehicles/vehicles.module';
 import { ReservationsModule } from './reservations/reservations.module';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -29,6 +31,11 @@ import { ReservationsModule } from './reservations/reservations.module';
     ReservationsModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService,
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,16 +2,19 @@ import { Controller, Post, Body } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from '../users/dto/create-user.dto';
 import { LoginDto } from './dto/login.dto';
+import { Public } from './decorators/public.decorator';
 
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
+  @Public()
   @Post('register')
   async register(@Body() createUserDto: CreateUserDto) {
     return this.authService.register(createUserDto);
   }
 
+  @Public()
   @Post('login')
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { UsersModule } from '../users/users.module';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtStrategy } from './strategies/jwt.strategy';
 
 @Module({
   imports: [
@@ -20,7 +21,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
       inject: [ConfigService],
     }),
   ],
-  providers: [AuthService],
+  providers: [AuthService, JwtStrategy],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/decorators/public.decorator.ts
+++ b/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Public = () => SetMetadata('isPublic', true);

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Reflector } from '@nestjs/core';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>('isPublic', [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,41 @@
+// src/auth/strategies/jwt.strategy.ts
+
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../../users/users.service';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private configService: ConfigService,
+    private usersService: UsersService,
+  ) {
+    super({
+      // 1. Diz ao Passport como extrair o Token (do Header 'Authorization')
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      // 2. Usa o MESMO segredo que usamos para criar o token (do .env)
+      secretOrKey: configService.get<string>('JWT_SECRET')!,
+    });
+  }
+
+  /**
+   * Este método é chamado pelo Passport DEPOIS de validar o token.
+   * O 'payload' é o que colocamos dentro do token (sub: user._id, email: user.email)
+   */
+  async validate(payload: { sub: string; email: string }) {
+    // 3. Pega o ID do payload e busca o usuário no banco
+    const user = await this.usersService.findById(payload.sub); // <-- Vamos criar este método
+
+    if (!user) {
+      throw new UnauthorizedException('Token inválido');
+    }
+
+    // 4. O objeto 'user' que retornamos aqui será "injetado"
+    // em qualquer rota protegida, dentro do `req.user`
+    const { password, ...result } = user.toObject();
+    return result;
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,8 +1,12 @@
-import { Controller, Get, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Req } from '@nestjs/common';
 import { UsersService } from './users.service';
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
+  @Get('me')
+  getProfile(@Req() req) {
+    return req.user;
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -16,4 +16,8 @@ export class UsersService {
   async findByEmail(email: string): Promise<UserDocument | null> {
     return this.userModel.findOne({ email: email }).exec();
   }
+
+  async findById(id: string): Promise<UserDocument | null> {
+    return this.userModel.findById(id).exec();
+  }
 }


### PR DESCRIPTION
Este PR implementa a estratégia de proteção de rotas global, conforme descrito na **Issue #5**. A partir de agora, todos os endpoints da API são protegidos por padrão, exigindo um Token JWT válido.

### O que foi feito:

* **Criação da `JwtStrategy`:** Implementada a lógica (`src/auth/strategies`) para validar o Token JWT, ler o `JWT_SECRET` do `.env` e buscar o usuário no banco (via `usersService.findById`).
* **Adição do `usersService.findById`:** Um novo método foi adicionado ao `UsersService` para suportar a `JwtStrategy`.
* **Criação do `JwtAuthGuard`:** Implementado o "Guarda" (`src/auth/guards`) que utiliza a `JwtStrategy`.
* **Decorator `@Public()`:** Criado um decorator (`src/auth/decorators`) para "liberar" rotas específicas do *Guard*.
* **Aplicação Global:** O `JwtAuthGuard` foi aplicado globalmente no `app.module.ts` (via `APP_GUARD`), garantindo que todas as rotas sejam protegidas por padrão.
* **Liberação das Rotas Públicas:** As rotas `POST /auth/register` e `POST /auth/login` foram marcadas com o decorator `@Public()`.
* **Teste de Validação:**
    * Criada uma rota de teste `GET /users/me` (protegida).
    * Teste **Sem Token** falhou com `401 (Unauthorized)` (correto).
    * Teste **Com Token** (Bearer) funcionou com `200 (OK)` e retornou os dados do usuário logado (correto).

Closes #5