### PR TITLE
feat(vehicle): implementa cadastro de veículo (Issue 9****)

### DIFF
--- a/src/vehicles/entities/vehicle.entity.ts
+++ b/src/vehicles/entities/vehicle.entity.ts
@@ -1,1 +1,0 @@
-export class Vehicle {}

--- a/src/vehicles/schemas/vehicle.schema.ts
+++ b/src/vehicles/schemas/vehicle.schema.ts
@@ -1,0 +1,33 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type VehicleDocument = HydratedDocument<Vehicle>;
+
+export enum VehicleStatus {
+  DISPONIVEL = 'disponivel',
+  RESERVADO = 'reservado',
+}
+
+@Schema({ timestamps: true })
+export class Vehicle {
+
+  @Prop({ required: true })
+  model: string;
+
+  @Prop({ required: true })
+  brand: string;
+
+  @Prop({ required: true })
+  type: string;
+
+  @Prop({ required: true })
+  motor: number;
+
+  @Prop({ required: true })
+  luggageCapacity: number;
+
+  @Prop({ required: true, enum: VehicleStatus, default: VehicleStatus.DISPONIVEL })
+  status: VehicleStatus;
+}
+
+export const VehicleSchema = SchemaFactory.createForClass(Vehicle);

--- a/src/vehicles/vehicles.controller.ts
+++ b/src/vehicles/vehicles.controller.ts
@@ -1,7 +1,6 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Post, Body } from '@nestjs/common';
 import { VehiclesService } from './vehicles.service';
 import { CreateVehicleDto } from './dto/create-vehicle.dto';
-import { UpdateVehicleDto } from './dto/update-vehicle.dto';
 
 @Controller('vehicles')
 export class VehiclesController {
@@ -10,25 +9,5 @@ export class VehiclesController {
   @Post()
   create(@Body() createVehicleDto: CreateVehicleDto) {
     return this.vehiclesService.create(createVehicleDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.vehiclesService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.vehiclesService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateVehicleDto: UpdateVehicleDto) {
-    return this.vehiclesService.update(+id, updateVehicleDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.vehiclesService.remove(+id);
   }
 }

--- a/src/vehicles/vehicles.module.ts
+++ b/src/vehicles/vehicles.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose'
 import { VehiclesService } from './vehicles.service';
 import { VehiclesController } from './vehicles.controller';
+import { Vehicle, VehicleSchema } from './schemas/vehicle.schema';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([{name: Vehicle.name, schema: VehicleSchema}]),
+  ],
   controllers: [VehiclesController],
   providers: [VehiclesService],
 })

--- a/src/vehicles/vehicles.service.ts
+++ b/src/vehicles/vehicles.service.ts
@@ -1,26 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
 import { CreateVehicleDto } from './dto/create-vehicle.dto';
-import { UpdateVehicleDto } from './dto/update-vehicle.dto';
+import { Vehicle, VehicleDocument } from './schemas/vehicle.schema';
 
 @Injectable()
 export class VehiclesService {
-  create(createVehicleDto: CreateVehicleDto) {
-    return 'This action adds a new vehicle';
-  }
+  constructor(
+    @InjectModel(Vehicle.name) private vehicleModel: Model<VehicleDocument>,
+  ) {}
 
-  findAll() {
-    return `This action returns all vehicles`;
-  }
-
-  findOne(id: number) {
-    return `This action returns a #${id} vehicle`;
-  }
-
-  update(id: number, updateVehicleDto: UpdateVehicleDto) {
-    return `This action updates a #${id} vehicle`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} vehicle`;
+  async create(createVehicleDto: CreateVehicleDto): Promise<VehicleDocument> {
+    const createdVehicle = new this.vehicleModel(createVehicleDto);
+    return createdVehicle.save();
   }
 }


### PR DESCRIPTION
Este PR implementa a funcionalidade de cadastro de novos veículos no sistema, conforme descrito na **Issue #9**.

### O que foi feito:

* **Criação do `VehicleSchema`:**
    * Criado o `vehicle.schema.ts` (convenção do Mongoose) e removido o `vehicle.entity.ts`.
    * O schema inclui os campos do `CreateVehicleDto` (model, brand, etc.) e um campo de controle interno `status` (do tipo `VehicleStatus`), com o `default: 'disponivel'`.
* **Configuração do `VehiclesModule`:** O módulo foi atualizado para importar o `MongooseModule` e carregar o `VehicleSchema`.
* **Lógica no `VehiclesService`:** O método `create` foi implementado para salvar o novo veículo no banco de dados.
* **Rota no `VehiclesController`:**
    * O endpoint `POST /vehicles` foi implementado, recebendo o `CreateVehicleDto` e chamando o `vehiclesService.create`.
    * Os métodos de CRUD (findAll, etc.) que causavam erros de compilação foram limpos.
* **Teste de Validação:**
    * A rota foi testada com sucesso via Postman.
    * O `JwtAuthGuard` (global) protegeu a rota corretamente (exigiu Bearer Token).
    * O `ValidationPipe` validou o DTO.
    * O veículo foi criado no banco de dados com o `status: "disponivel"`.

Closes #9