### PR TITLE
feat(reservation): implementa reserva de veículo e regras de negócio (Issues 12, 13)

### DIFF
--- a/src/reservations/entities/reservation.entity.ts
+++ b/src/reservations/entities/reservation.entity.ts
@@ -1,1 +1,0 @@
-export class Reservation {}

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -1,34 +1,19 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Post, Body, Req, Get } from '@nestjs/common';
 import { ReservationsService } from './reservations.service';
 import { CreateReservationDto } from './dto/create-reservation.dto';
-import { UpdateReservationDto } from './dto/update-reservation.dto';
+import type { Request } from 'express';
 
 @Controller('reservations')
 export class ReservationsController {
-  constructor(private readonly reservationsService: ReservationsService) {}
+  constructor(private readonly reservationsService: ReservationsService) { }
 
   @Post()
-  create(@Body() createReservationDto: CreateReservationDto) {
-    return this.reservationsService.create(createReservationDto);
-  }
+  create(
+    @Body() createReservationDto: CreateReservationDto,
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as any)._id;
 
-  @Get()
-  findAll() {
-    return this.reservationsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.reservationsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateReservationDto: UpdateReservationDto) {
-    return this.reservationsService.update(+id, updateReservationDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.reservationsService.remove(+id);
+    return this.reservationsService.create(createReservationDto, userId);
   }
 }

--- a/src/reservations/reservations.module.ts
+++ b/src/reservations/reservations.module.ts
@@ -1,8 +1,20 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 import { ReservationsService } from './reservations.service';
 import { ReservationsController } from './reservations.controller';
+import {
+  Reservation,
+  ReservationSchema,
+} from './schemas/reservation.schema';
+import { VehiclesModule } from '../vehicles/vehicles.module';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Reservation.name, schema: ReservationSchema },
+    ]),
+    VehiclesModule,
+  ],
   controllers: [ReservationsController],
   providers: [ReservationsService],
 })

--- a/src/reservations/schemas/reservation.schema.ts
+++ b/src/reservations/schemas/reservation.schema.ts
@@ -1,0 +1,17 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Types } from 'mongoose';
+import { User } from '../../users/schemas/user.schema';
+import { Vehicle } from '../../vehicles/schemas/vehicle.schema';
+
+export type ReservationDocument = HydratedDocument<Reservation>;
+
+@Schema({ timestamps: true })
+export class Reservation {
+  @Prop({ type: Types.ObjectId, ref: User.name, required: true })
+  userId: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: Vehicle.name, required: true })
+  vehicleId: Types.ObjectId;
+}
+
+export const ReservationSchema = SchemaFactory.createForClass(Reservation);

--- a/src/vehicles/vehicles.module.ts
+++ b/src/vehicles/vehicles.module.ts
@@ -10,5 +10,6 @@ import { Vehicle, VehicleSchema } from './schemas/vehicle.schema';
   ],
   controllers: [VehiclesController],
   providers: [VehiclesService],
+  exports: [VehiclesService],
 })
 export class VehiclesModule {}

--- a/src/vehicles/vehicles.service.ts
+++ b/src/vehicles/vehicles.service.ts
@@ -18,4 +18,17 @@ export class VehiclesService {
   async findAll(): Promise<VehicleDocument[]> {
     return this.vehicleModel.find().exec();
   }
+
+  async findById(id: string): Promise<VehicleDocument | null> {
+    return this.vehicleModel.findById(id).exec();
+  }
+
+  async updateStatus(
+    id: string,
+    status: string,
+  ): Promise<VehicleDocument | null> {
+    return this.vehicleModel
+      .findByIdAndUpdate(id, { status: status }, { new: true })
+      .exec();
+  }
 }


### PR DESCRIPTION
Este PR implementa a funcionalidade central da aplicação: a reserva de veículos, incluindo as regras de negócio críticas, conforme descrito nas Issues #12 e #13.

### O que foi feito:

* **Criação do `ReservationSchema`:**
    * Criado o `reservation.schema.ts` (convenção do Mongoose) e removido o `reservation.entity.ts`.
    * O schema usa `Types.ObjectId` e `ref` para "apontar" corretamente para os documentos `User` e `Vehicle`, estabelecendo a relação.
* **Atualização do `VehiclesModule/Service`:**
    * O `VehiclesService` foi exportado no módulo.
    * Novos métodos (`findById` e `updateStatus`) foram adicionados ao `VehiclesService` para serem usados pelo `ReservationsService`.
* **Configuração do `ReservationsModule`:** O módulo agora importa o `MongooseModule` (com o `ReservationSchema`) e o `VehiclesModule`.
* **Lógica de Negócio (`ReservationsService`):** O método `create` foi implementado com toda a lógica de validação:
    * **(Issue 13)** Verifica se o `userId` (vindo do token) já possui uma reserva ativa. Lança `ConflictException (409)` se sim. (Validado com Teste 2 ✅).
    * **(Issue 12)** Verifica se o `vehicleId` existe (`NotFoundException`) e se o `status` é "disponivel". Lança `ConflictException (409)` se já estiver "reservado". (Validado com Teste 3 ✅).
    * Se as regras passarem, o serviço atualiza o status do veículo para `reservado` e cria o documento da reserva.
* **Rota no `ReservationsController`:**
    * O endpoint `POST /reservations` foi criado.
    * Ele usa `@Req() req` para extrair o `userId` (`req.user._id`) injetado pelo `JwtAuthGuard`.
    * O `userId` e o `vehicleId` (do DTO) são passados para o serviço.
* **Testes de Validação (Passo a Passo):**
    * Teste 1 (Caminho Feliz): Usuário 1 reserva Veículo 1 -> `201 Created` ✅.
    * Teste 2 (Regra Usuário): Usuário 1 tenta reservar Veículo 2 -> `409 Conflict` ✅.
    * Teste 3 (Regra Veículo): Usuário 2 tenta reservar Veículo 1 -> `409 Conflict` ✅.

Closes #12, Closes #13