### PR TITLE
feat(reservation): Implementa liberação de veículo (DELETE /reservations/me) (Issue 15)

### DIFF
--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Req, Get } from '@nestjs/common';
+import { Controller, Post, Body, Req, Get, Delete } from '@nestjs/common';
 import { ReservationsService } from './reservations.service';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import type { Request } from 'express';
@@ -16,10 +16,15 @@ export class ReservationsController {
 
     return this.reservationsService.create(createReservationDto, userId);
   }
-    @Get('me')
-      findMyReservation(@Req() req: Request) {
-        const userId = (req.user as any)._id;
+  @Get('me')
+  findMyReservation(@Req() req: Request) {
+    const userId = (req.user as any)._id;
 
-        return this.reservationsService.findForUser(userId);
-      }
+    return this.reservationsService.findForUser(userId);
+  }
+  @Delete('me')
+  cancelMyReservation(@Req() req: Request) {
+    const userId = (req.user as any) ._id;
+    return this.reservationsService.cancelForUser(userId);
+  }
 }

--- a/src/reservations/reservations.service.ts
+++ b/src/reservations/reservations.service.ts
@@ -65,4 +65,21 @@ export class ReservationsService {
       .populate('vehicleId')
       .exec();
   }
+
+  async  cancelForUser (userId: string ) {
+    const reservation = await  this.reservationModel
+    .findOne ({userId: new Types.ObjectId(userId) })
+    .exec();
+
+    if (!reservation) {
+      throw new NotFoundException('Você não possui uma reserva ativa para cancelar.')
+    }
+
+    await this.vehiclesService.updateStatus(
+      reservation.vehicleId.toString(),
+      VehicleStatus.DISPONIVEL,
+    );
+
+    return this.reservationModel.deleteOne({ _id: reservation._id});
+  }
 }


### PR DESCRIPTION
Este PR implementa a funcionalidade que permite a um utilizador logado cancelar/liberar a sua reserva ativa, conforme descrito na **Issue #15**.

### O que foi feito:

* **Lógica no `ReservationsService`:** O método `cancelForUser` foi implementado:
    1.  Procura a reserva ativa do `userId`.
    2.  Lança um `NotFoundException (404)` se nenhuma reserva for encontrada.
    3.  Atualiza o `status` do veículo associado de volta para `disponivel` (via `vehiclesService.updateStatus`).
    4.  Apaga o documento da reserva (`deleteOne`).
* **Correção de Bug (Typo):** Corrigido um typo *case-sensitive* na query do `findOne` (de `userID` para `userId`), o que resolveu o bug 404 que ocorria mesmo quando a reserva existia.
* **Rota no `ReservationsController`:** O endpoint `DELETE /reservations/me` foi adicionado, extraindo o `userId` do `@Req() req` para chamar o serviço.
* **Teste de Validação:**
    * O fluxo completo (Criar Reserva -> Tentar Deletar) foi testado com sucesso, retornando `200 OK` e `deletedCount: 1`.
    * O teste de verificação (Tentar Deletar 2x) falhou corretamente com `404 Not Found`.
    * O status do veículo foi verificado e voltou para `disponivel`.

Closes #15