### PR TITLE
feat(user): Implementa rota de Remoção de Usuário (DELETE /users/:id) (Issue 8)

### DIFF
--- a/src/reservations/reservations.module.ts
+++ b/src/reservations/reservations.module.ts
@@ -17,5 +17,6 @@ import { VehiclesModule } from '../vehicles/vehicles.module';
   ],
   controllers: [ReservationsController],
   providers: [ReservationsService],
+  exports:  [ReservationsService],
 })
 export class ReservationsModule {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req, Put, Param, Body, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Req, Put, Param, Body, ForbiddenException, NotFoundException, Delete } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { ApiTags } from '@nestjs/swagger';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -35,6 +35,29 @@ export class UsersController {
     }
 
     const { password, ...result } = updatedUser.toObject();
+    return result;
+  }
+
+  @Delete(':id')
+  async remove(
+    @Param('id') id: string,
+    @Req() req: Request,
+  ) {
+    const loggedInUserId = (req.user as any)._id;
+
+    if (loggedInUserId.toString() !== id) {
+      throw new ForbiddenException(
+        'Você não tem permissão para deletar este usuário.',
+      );
+    }
+
+    const deletedUser = await this.usersService.remove(id);
+
+    if (!deletedUser) {
+      throw new NotFoundException('Usuário não encontrado para deleção.');
+    }
+
+    const { password, ...result } = deletedUser.toObject();
     return result;
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,10 +3,12 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from './schemas/user.schema';
+import { ReservationsModule } from '../reservations/reservations.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{name: User.name, schema: UserSchema}]),
+    ReservationsModule,
   ],
   controllers: [UsersController],
   providers: [UsersService],


### PR DESCRIPTION
Este PR implementa a funcionalidade de deleção de usuário, incluindo a lógica de deleção em cascata da sua reserva, conforme descrito na **Issue #8**.

### O que foi feito:

* **Injeção de Dependência:** O `ReservationsModule` foi importado pelo `UsersModule` e o `ReservationsService` foi injetado no `UsersService`.
* **Lógica no `UsersService`:**
    * O método `remove` foi implementado.
    * **Lógica de Cascata:** O método agora chama `this.reservationsService.cancelForUser(id)` dentro de um bloco `try/catch` antes de deletar o usuário. Isso garante que, se o usuário tiver uma reserva, ela seja cancelada e o status do veículo volte para "disponivel".
    * O `catch` ignora corretamente os erros 404 (caso o usuário não tenha reserva).
* **Rota no `UsersController`:**
    * O endpoint `DELETE /users/:id` foi adicionado.
    * **Regra de Segurança:** Foi implementada a verificação para garantir que o ID do usuário logado (`req.user._id`) é o mesmo do `id` no parâmetro.
* **Teste de Validação:**
    * Teste 1 (Segurança): Tentar deletar outro usuário -> `403 Forbidden` ✅.
    * Teste 2 (Cascata): Usuário A (com reserva) se deletou -> `200 OK` ✅.
    * Teste 3 (Verificação 1): Status do veículo reservado voltou para "disponivel" ✅.
    * Teste 4 (Verificação 2): Usuário A não consegue mais logar -> `401 Unauthorized` ✅.

Closes #8