### PR TITLE
feat(security): Implementa RBAC (Roles Guard) e Admin Role (Issue 19)

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -48,7 +48,7 @@ export class AuthService {
       throw new UnauthorizedException('Credenciais inválidas');
     }
 
-    const payload = { sub: user._id, email: user.email };
+    const payload = { sub: user._id, email: user.email, roles: user.roles };
     const accessToken = await this.jwtService.signAsync(payload);
 
     return {

--- a/src/auth/decorators/roles.decorator.ts
+++ b/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../enums/role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/enums/role.enum.ts
+++ b/src/auth/enums/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  User = 'user',
+  Admin = 'admin',
+}

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,39 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../enums/role.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+
+    const userRoles = Array.isArray(user.roles) ? user.roles: []
+
+    const hasRole = requiredRoles.some((role) => user.roles?.includes(role));
+
+    if (!hasRole) {
+      throw new ForbiddenException(
+        'Você não tem permissão para acessar a este recurso.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,5 +1,3 @@
-// src/auth/strategies/jwt.strategy.ts
-
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
@@ -13,29 +11,24 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private usersService: UsersService,
   ) {
     super({
-      // 1. Diz ao Passport como extrair o Token (do Header 'Authorization')
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      // 2. Usa o MESMO segredo que usamos para criar o token (do .env)
       secretOrKey: configService.get<string>('JWT_SECRET')!,
     });
   }
 
-  /**
-   * Este método é chamado pelo Passport DEPOIS de validar o token.
-   * O 'payload' é o que colocamos dentro do token (sub: user._id, email: user.email)
-   */
-  async validate(payload: { sub: string; email: string }) {
-    // 3. Pega o ID do payload e busca o usuário no banco
-    const user = await this.usersService.findById(payload.sub); // <-- Vamos criar este método
+  async validate(payload: { sub: string; email: string, roles: string[]; }) {
+    const user = await this.usersService.findById(payload.sub);
 
     if (!user) {
       throw new UnauthorizedException('Token inválido');
     }
 
-    // 4. O objeto 'user' que retornamos aqui será "injetado"
-    // em qualquer rota protegida, dentro do `req.user`
-    const { password, ...result } = user.toObject();
-    return result;
+    const { password, ...result } = user.toObject();    
+    return {
+        _id: result._id,
+        email: result.email,
+        roles: result.roles
+    };
   }
 }

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
+import { Role } from '../../auth/enums/role.enum';
 
 export type UserDocument = HydratedDocument<User>;
 
@@ -13,6 +14,9 @@ export class User {
 
   @Prop({ required: true })
   password: string;
+
+  @Prop({ type: [String], enum: Role, default: [Role.User] })
+  roles: Role[];
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/src/vehicles/vehicles.controller.ts
+++ b/src/vehicles/vehicles.controller.ts
@@ -1,15 +1,20 @@
-import { Controller, Post, Body, Get, Patch, Param, Delete, NotFoundException } from '@nestjs/common';
+import { Controller, Post, Body, Get, Patch, Param, Delete, NotFoundException, UseGuards } from '@nestjs/common';
 import { VehiclesService } from './vehicles.service';
 import { CreateVehicleDto } from './dto/create-vehicle.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { UpdateVehicleDto } from './dto/update-vehicle.dto';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Role } from '../auth/enums/role.enum';
 
 @ApiTags('3. Veículos')
+@UseGuards(RolesGuard)
 @Controller('vehicles')
 export class VehiclesController {
   constructor(private readonly vehiclesService: VehiclesService) {}
 
   @Post()
+  @Roles(Role.Admin)
   create(@Body() createVehicleDto: CreateVehicleDto) {
     return this.vehiclesService.create(createVehicleDto);
   }
@@ -20,6 +25,7 @@ export class VehiclesController {
   }
 
   @Patch(':id')
+  @Roles(Role.Admin)
   async update(
     @Param('id') id: string,
     @Body() updateVehicleDto: UpdateVehicleDto,
@@ -35,6 +41,7 @@ export class VehiclesController {
   }
 
   @Delete(':id')
+  @Roles(Role.Admin)
   async remove(@Param('id') id: string) {
     const deletedVehicle = await this.vehiclesService.remove(id);
     if (!deletedVehicle) {


### PR DESCRIPTION
Este PR implementa o Controle de Acesso Baseado em Nível (RBAC) para proteger as rotas de gerenciamento, conforme a **Issue #19**.

### O que foi feito:

* **Estrutura de Roles:** Criado o `Role` Enum (`src/auth/enums`) e adicionado o campo `roles` ao `user.schema.ts` (default: `['user']`).
* **Fluxo de Autenticação:** O `AuthService` e o `JwtStrategy` foram atualizados para incluir a lista de `roles` no payload do Token JWT.
* **Componentes de Segurança:**
    * Criado o decorator `@Roles` (`src/auth/decorators`) para marcar as rotas com o nível de acesso necessário.
    * Criado o `RolesGuard` (`src/auth/guards`) para verificar se os `roles` do token do usuário correspondem aos `roles` exigidos pela rota.
* **Proteção de Rotas:**
    * As rotas `POST /vehicles`, `PATCH /vehicles/:id`, e `DELETE /vehicles/:id` no `VehiclesController` foram protegidas com `@Roles(Role.Admin)`.
* **Teste de Validação:**
    * **User Normal:** Falhou com `403 Forbidden` ao tentar criar um veículo. ✅
    * **User Normal:** Sucesso com `200 OK` ao tentar listar veículos (rota sem o `@Roles`). ✅
    * **User Admin:** Sucesso com `201 Created` ao criar um veículo. ✅

Closes #19