### PR TITLE
fix(vehicle): Adiciona campo imageUrl ao Schema e DTO

### DIFF
--- a/src/vehicles/dto/create-vehicle.dto.ts
+++ b/src/vehicles/dto/create-vehicle.dto.ts
@@ -20,4 +20,8 @@ export class CreateVehicleDto {
   @IsInt()
   @IsNotEmpty()
   luggageCapacity: number;
+
+  @IsString()
+  @IsNotEmpty()
+  imageUrl: string;
 }

--- a/src/vehicles/schemas/vehicle.schema.ts
+++ b/src/vehicles/schemas/vehicle.schema.ts
@@ -28,6 +28,9 @@ export class Vehicle {
 
   @Prop({ required: true, enum: VehicleStatus, default: VehicleStatus.DISPONIVEL })
   status: VehicleStatus;
+
+  @Prop({ required: true })
+  imageUrl: string;
 }
 
 export const VehicleSchema = SchemaFactory.createForClass(Vehicle);


### PR DESCRIPTION
Este PR implementa a "Correção de Arquitetura 1" (Caminho 1), garantindo que a API seja a "fonte da verdade" para as imagens dos veículos

### O que foi feito:

* **`vehicle.schema.ts`:** Adicionado o campo `imageUrl: string` (requerido) ao schema do Mongoose.
* **`create-vehicle.dto.ts`:** Adicionado o campo `imageUrl` (requerido, com validadores `@IsString` e `@IsNotEmpty`) ao DTO de criação.
* **`update-vehicle.dto.ts`:** O campo `imageUrl` (opcional) foi automaticamente herdado via `PartialType`.

Esta mudança prepara o backend para que o frontend possa consumir a URL da imagem diretamente da API, em vez de usar um "mapa" local.

**Próximos Passos (Após o Merge):**
1. Aguardar o deploy no Railway.
2. Limpar (Drop) a coleção `vehicles` no Atlas (para remover dados antigos/inválidos).
3. Repopular o banco de dados (via Postman) com os 12 carros, agora incluindo o campo `imageUrl`.